### PR TITLE
Replace deprecated classes

### DIFF
--- a/src/main/java/com/ge/predix/labs/data/jpa/config/CloudFoundryDataSourceConfiguration.java
+++ b/src/main/java/com/ge/predix/labs/data/jpa/config/CloudFoundryDataSourceConfiguration.java
@@ -6,7 +6,7 @@ import java.util.Map;
 import javax.sql.DataSource;
 
 import org.hibernate.dialect.PostgreSQLDialect;
-import org.hibernate.ejb.HibernatePersistence;
+import org.hibernate.jpa.HibernatePersistenceProvider;
 import org.springframework.cache.CacheManager;
 import org.springframework.cloud.config.java.AbstractCloudConfig;
 import org.springframework.context.annotation.Bean;
@@ -44,7 +44,7 @@ public class CloudFoundryDataSourceConfiguration extends AbstractCloudConfig  {
         LocalContainerEntityManagerFactoryBean em = new LocalContainerEntityManagerFactoryBean();
         em.setDataSource( dataSource );
         em.setPackagesToScan(Customer.class.getPackage().getName());
-        em.setPersistenceProvider(new HibernatePersistence());
+        em.setPersistenceProvider(new HibernatePersistenceProvider());
         Map<String, String> p = new HashMap<String, String>();
         p.put(org.hibernate.cfg.Environment.HBM2DDL_AUTO, "create");
         p.put(org.hibernate.cfg.Environment.HBM2DDL_IMPORT_FILES, "initialCustomers.sql");

--- a/src/main/java/com/ge/predix/labs/data/jpa/config/CloudFoundryDataSourceConfiguration.java
+++ b/src/main/java/com/ge/predix/labs/data/jpa/config/CloudFoundryDataSourceConfiguration.java
@@ -5,7 +5,7 @@ import java.util.Map;
 
 import javax.sql.DataSource;
 
-import org.hibernate.dialect.PostgreSQLDialect;
+import org.hibernate.dialect.PostgreSQL82Dialect;
 import org.hibernate.jpa.HibernatePersistenceProvider;
 import org.springframework.cache.CacheManager;
 import org.springframework.cloud.config.java.AbstractCloudConfig;
@@ -48,7 +48,7 @@ public class CloudFoundryDataSourceConfiguration extends AbstractCloudConfig  {
         Map<String, String> p = new HashMap<String, String>();
         p.put(org.hibernate.cfg.Environment.HBM2DDL_AUTO, "create");
         p.put(org.hibernate.cfg.Environment.HBM2DDL_IMPORT_FILES, "initialCustomers.sql");
-        p.put(org.hibernate.cfg.Environment.DIALECT, PostgreSQLDialect.class.getName());
+        p.put(org.hibernate.cfg.Environment.DIALECT, PostgreSQL82Dialect.class.getName());
         p.put(org.hibernate.cfg.Environment.SHOW_SQL, "true");
         em.setJpaPropertyMap(p);
         return em;


### PR DESCRIPTION
When I try `mvn clean package`, I saw two warning messages.

Warning:(8, 29) java: org.hibernate.dialect.PostgreSQLDialect in org.hibernate.dialect has been deprecated
Warning:(9, 25) java: org.hibernate.ejb.HibernatePersistence in org.hibernate.ejb has been deprecated

So, I've replaced deprecated library to recommended library which is described on official documentation.

Unfortunately, I have no same cf environment to test this. I think this project need self test environment which can run on developer's own PC. So, check this code before merge.